### PR TITLE
日付にタイムゾーンを使用するように修正

### DIFF
--- a/application/apis/narou/narou_data.py
+++ b/application/apis/narou/narou_data.py
@@ -2,8 +2,9 @@
 
 import uuid
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 
+from common.datetime_util import jst_strptime
 from config.log import console_logger
 
 
@@ -34,9 +35,7 @@ class NarouRankDataMapper:
         data_list = []
         try:
             for data in response.json():
-                data["rank_date"] = datetime.strptime(
-                    str(rank_date), "%Y%m%d"
-                ).date()
+                data["rank_date"] = jst_strptime(str(rank_date)).date()
                 data["id"] = str(uuid.uuid4())
                 data["rank_type"] = rank_type.value
                 data_list.append(NarouRankData(**data))

--- a/application/apis/narou/type.py
+++ b/application/apis/narou/type.py
@@ -1,8 +1,8 @@
 """なろうランキングのEnum関連."""
 
-from datetime import datetime
 from enum import Enum
 
+from common.datetime_util import jst_strptime
 from config.log import console_logger
 
 
@@ -44,7 +44,7 @@ class RankType(Enum):
             ```
         """
         try:
-            parsed_date = datetime.strptime(date, "%Y%m%d")
+            parsed_date = jst_strptime(date)
             if rank_type == RankType.WEEKLY and parsed_date.weekday() != 1:
                 console_logger.warning(
                     "週間を指定する場合の日付は火曜日の日付を指定"
@@ -58,7 +58,7 @@ class RankType(Enum):
                     "月間、四半期を取得する場合、日付は1日を指定"
                 )
                 return False
-            elif parsed_date < datetime(2013, 5, 1):
+            elif parsed_date < jst_strptime("20130501"):
                 console_logger.warning("2013年5月1日以降の日付を指定")
                 return False
             return True

--- a/application/batch/get_ranking.py
+++ b/application/batch/get_ranking.py
@@ -1,7 +1,5 @@
 """日刊ランキング取得バッチ."""
 
-from datetime import datetime
-
 from prefect import flow, task
 from prefect.runtime import flow_run
 
@@ -9,6 +7,7 @@ from apis.narou.narou_data import NarouRankDataMapper
 from apis.narou.type import RankType
 from apis.narou.urls import NarouRankURLBuilder
 from apis.request import request_get
+from common.datetime_util import jst_now, jst_strptime
 from config.db import get_session
 from config.log import console_logger
 from repository.daily_get_ranking_repository import ranking_insert
@@ -28,15 +27,15 @@ def process_command_args(args):
         rank_date = args[0]
         try:
             # 日付形式の確認
-            parsed_date = datetime.strptime(rank_date, "%Y%m%d")
+            parsed_date = jst_strptime(rank_date)
             # 未来日のチェック
-            if parsed_date > datetime.now():
+            if parsed_date > jst_now():
                 raise ValueError("rank_dateは未来日を指定できません。")
         except ValueError as e:
             raise ValueError(f"無効なrank_dateが指定されました: {e}")
     else:
         # 引数が指定されていない場合は現在日時を使用
-        rank_date = datetime.now().strftime("%Y%m%d")
+        rank_date = jst_now().strftime("%Y%m%d")
 
     # rank_typeの処理
     rank_type_list = []
@@ -66,7 +65,7 @@ def generate_flow_run_name():
     parameters = flow_run.parameters
     rank_date = parameters["rank_date"]
     if not rank_date:
-        rank_date = datetime.now().strftime("%Y%m%d")
+        rank_date = jst_now().strftime("%Y%m%d")
     rank_type = parameters["rank_type"]
     if not rank_type:
         rank_type = "all"

--- a/application/command/all_ranking.py
+++ b/application/command/all_ranking.py
@@ -1,8 +1,9 @@
 """全てのランキングを投入用."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from batch.get_ranking import get_ranking
+from common.datetime_util import jst_now, jst_strptime
 from config.log import console_logger
 
 
@@ -18,8 +19,8 @@ def generate_date_strings(start_date: str):
     if not start_date.isdigit() or len(start_date) != 8:
         raise ValueError("開始日は8桁の数字（YYYYMMDD）で指定してください")
 
-    start = datetime.strptime(start_date, "%Y%m%d")
-    today = datetime.now()
+    start = jst_strptime(start_date)
+    today = jst_now()
 
     if start > today:
         raise ValueError("開始日は現在日より前の日付を指定してください")

--- a/application/common/datetime_util.py
+++ b/application/common/datetime_util.py
@@ -1,0 +1,16 @@
+"""datetime関連."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def jst_strptime(date_string, format="%Y%m%d"):
+    """文字列をJST (日本標準時) タイムゾーン付きのdatetimeオブジェクトに変換."""
+    return datetime.strptime(date_string, format).replace(
+        tzinfo=ZoneInfo("Asia/Tokyo")
+    )
+
+
+def jst_now():
+    """現在の時刻をJST (日本標準時) タイムゾーン付きの datetime オブジェクトとして返す."""
+    return datetime.now(ZoneInfo("Asia/Tokyo"))

--- a/application/tests/batch/test_get_ranking.py
+++ b/application/tests/batch/test_get_ranking.py
@@ -1,17 +1,18 @@
 """なろうランキング取得処理関連のテスト."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 
 from apis.narou.type import RankType
 from batch.get_ranking import process_command_args
+from common.datetime_util import jst_now
 
 
 # process_command_argsのテスト
 def test_future_date():
     """未来日のrank_dateが指定された場合はエラー."""
-    future_date = (datetime.now() + timedelta(days=1)).strftime("%Y%m%d")
+    future_date = (jst_now() + timedelta(days=1)).strftime("%Y%m%d")
     args = [future_date, "d"]
     with pytest.raises(ValueError, match="rank_dateは未来日を指定できません"):
         process_command_args(args)
@@ -28,7 +29,7 @@ def test_no_argument():
     """引数が指定されていない場合は現在日時とデフォルトのrank_typeを使用."""
     args = []
     results = process_command_args(args)
-    expected_date = datetime.now().strftime("%Y%m%d")
+    expected_date = jst_now().strftime("%Y%m%d")
     assert results[0] == expected_date
     assert results[1] == [RankType.DAILY]
 
@@ -37,7 +38,7 @@ def test_empty_date_argument():
     """空のrank_date引数が渡された場合は現在日とする."""
     args = ["", "d"]
     results = process_command_args(args)
-    expected_date = datetime.now().strftime("%Y%m%d")
+    expected_date = jst_now().strftime("%Y%m%d")
     assert results[0] == expected_date
     assert results[1] == [RankType.DAILY]
 

--- a/application/tests/factories/rank.py
+++ b/application/tests/factories/rank.py
@@ -4,6 +4,7 @@ import datetime
 
 import factory
 
+from common.datetime_util import jst_now
 from models.rank import Rank
 
 
@@ -24,10 +25,6 @@ class RankFactory(factory.alchemy.SQLAlchemyModelFactory):
     rank_date = factory.LazyFunction(
         lambda: datetime.date.today()
     )  # 今日の日付を生成
-    created_at = factory.LazyFunction(
-        lambda: datetime.datetime.now()
-    )  # 現在時刻を使用
-    updated_at = factory.LazyFunction(
-        lambda: datetime.datetime.now()
-    )  # 現在時刻を使用
+    created_at = factory.LazyFunction(lambda: jst_now())  # 現在時刻を使用
+    updated_at = factory.LazyFunction(lambda: jst_now())  # 現在時刻を使用
     deleted_at = None

--- a/application/tests/repository/test_daily_get_ranking_repository.py
+++ b/application/tests/repository/test_daily_get_ranking_repository.py
@@ -1,10 +1,11 @@
 """なろうランキングの挿入関連のテスト."""
 
-from datetime import datetime
+# from datetime import datetime
 
 import pytest
 
 from apis.narou.narou_data import NarouRankData
+from common.datetime_util import jst_strptime
 from models.ncode_mapping import NcodeMapping
 from models.rank import Rank
 from repository.daily_get_ranking_repository import ranking_insert
@@ -105,14 +106,14 @@ def test_rank_table_insertion(db, initial_narou_rank_data):
     assert rank_results[0].rank == 1
     assert (
         rank_results[0].rank_date
-        == datetime.strptime("20241211", "%Y%m%d").date()
+        == jst_strptime("20241211").date()
     )
     assert rank_results[0].rank_type == "d"
     assert rank_results[1].id == "2"
     assert rank_results[1].rank == 2
     assert (
         rank_results[1].rank_date
-        == datetime.strptime("20241211", "%Y%m%d").date()
+        == jst_strptime("20241211").date()
     )
     assert rank_results[1].rank_type == "d"
 
@@ -136,7 +137,7 @@ def test_rank_table_with_duplicate_ncode(
     assert rank_results[0].rank == 1
     assert (
         rank_results[0].rank_date
-        == datetime.strptime("20241211", "%Y%m%d").date()
+        == jst_strptime("20241211").date()
     )
     assert rank_results[0].rank_type == "d"
 
@@ -144,7 +145,7 @@ def test_rank_table_with_duplicate_ncode(
     assert rank_results[1].rank == 2
     assert (
         rank_results[1].rank_date
-        == datetime.strptime("20241211", "%Y%m%d").date()
+        == jst_strptime("20241211").date()
     )
     assert rank_results[1].rank_type == "d"
 
@@ -153,7 +154,7 @@ def test_rank_table_with_duplicate_ncode(
     assert rank_results[2].rank == 1
     assert (
         rank_results[2].rank_date
-        == datetime.strptime("20241212", "%Y%m%d").date()
+        == jst_strptime("20241212").date()
     )
     assert rank_results[2].rank_type == "d"
 
@@ -161,6 +162,6 @@ def test_rank_table_with_duplicate_ncode(
     assert rank_results[3].rank == 2
     assert (
         rank_results[3].rank_date
-        == datetime.strptime("20241212", "%Y%m%d").date()
+        == jst_strptime("20241212").date()
     )
     assert rank_results[3].rank_type == "d"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 日本標準時(JST)に基づく日付処理のためのユーティリティ関数`jst_strptime`と`jst_now`を追加しました。

- **バグ修正**
  - 日付のパースと比較処理を改善し、一貫性を持たせました。

- **テスト**
  - テストケースでの日付取得を`jst_now`に変更し、日付パースに`jst_strptime`を使用するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->