### PR TITLE
DBから取得したデータがない場合に空リストを返却することを定義

### DIFF
--- a/application/repository/get_novel_data_repository.py
+++ b/application/repository/get_novel_data_repository.py
@@ -11,7 +11,7 @@ base_dir = Path(__file__).parent
 sub_dirs = ["sql", "get_novel_data_repository"]
 
 
-def get_target_novel_data(session):
+def get_target_novel_data(session) -> list[dict]:
     """ncode_mappingにあり、novelにないデータを取得."""
     console_logger.debug("ncode_mappingにあり、novelにないデータを取得")
     sql_query = get_sql_query("get_target_novel_data.sql", base_dir, sub_dirs)

--- a/application/tests/batch/test_get_novel_data.py
+++ b/application/tests/batch/test_get_novel_data.py
@@ -31,6 +31,13 @@ def test_get_target_from_db(mocker):
     ]
 
 
+def test_get_target_from_db_empty(mocker):
+    """DBから取得したデータが空のケース."""
+    mocker.patch("batch.get_novel_data.get_target_novel_data", return_value=[])
+    data_list = get_target_from_db.fn()
+    assert data_list == []
+
+
 # fetch_novel_info
 def test_fetch_novel_info(
     mocker, narou_response_value, ncode_mapping_data_list

--- a/application/tests/repository/test_get_novel_data_repository.py
+++ b/application/tests/repository/test_get_novel_data_repository.py
@@ -35,3 +35,9 @@ def test_get_target_novel_data(db, novel_without_ncode_mapping, novel):
     assert len(results) == 1
     assert results[0].get("id") == novel_without_ncode_mapping.id
     assert results[0].get("ncode") == novel_without_ncode_mapping.ncode
+
+
+def test_get_target_novel_data_empty(db, novel):
+    """取得したデータが空の場合のテスト."""
+    results = get_target_novel_data(db)
+    assert results == []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `get_target_novel_data` 関数の戻り値の型注釈が追加され、戻り値がリストの辞書であることが明示化されました。

- **バグ修正**
	- データベースからの空のデータセットに対するテストが追加され、空のレスポンスに対する処理が強化されました。

- **テスト**
	- `get_target_novel_data` 関数が空のリストを返すことを確認する新しいテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->