### PR TITLE
なろうAPIでは取得する件数を指定しないと20件になるため、件数を指定するように修正

### DIFF
--- a/application/apis/narou/urls.py
+++ b/application/apis/narou/urls.py
@@ -14,6 +14,7 @@ class NarouParamsKey(Enum):
     NCODE = "ncode"
     OF = "of"
     ORDER = "order"
+    LIMIT = "lim"
 
 
 class NarouURLBuilder:
@@ -51,6 +52,15 @@ class NarouURLBuilder:
         self._params[NarouParamsKey.ORDER.value] = order.value
         return self
 
+    def set_limit(self, limit: int):
+        """出力数を指定(1 ~ 500)."""
+        if limit <= 0:
+            limit = 1
+        elif limit > 500:
+            limit = 500
+        self._params[NarouParamsKey.LIMIT.value] = limit
+        return self
+
     def build(self) -> str:
         """クエリを組み立ててURLを生成."""
         out_put = self._params.get(NarouParamsKey.OUTPUT_FORMAT.value)
@@ -71,7 +81,13 @@ class NarouURLBuilder:
         if order is not None:
             order = f"{NarouParamsKey.ORDER.value}={order}"
 
-        params = [x for x in (out_put, ncode, of, order) if x is not None]
+        limit = self._params.get(NarouParamsKey.LIMIT.value)
+        if limit is not None:
+            limit = f"{NarouParamsKey.LIMIT.value}={limit}"
+
+        params = [
+            x for x in (out_put, ncode, of, order, limit) if x is not None
+        ]
         query = "&".join(params)
         return f"{self._base_url}?{query}"
 

--- a/application/tests/apis/narou/test_urls.py
+++ b/application/tests/apis/narou/test_urls.py
@@ -114,6 +114,7 @@ def test_NarouURLBuilder_only_output_format():
     assert "ncode=" not in url  # ncodeが含まれない
     assert "of=" not in url  # ofが含まれない
     assert "order=" not in url  # orderが含まれない
+    assert "lim=" not in url  # limitが含まれない
 
 
 def test_NarouURLBuilder_only_ncode():
@@ -123,6 +124,7 @@ def test_NarouURLBuilder_only_ncode():
     assert "out=" not in url  # 出力形式が含まれない
     assert "of=" not in url  # ofが含まれない
     assert "order=" not in url  # orderが含まれない
+    assert "lim=" not in url  # limitが含まれない
 
 
 def test_NarouURLBuilder_only_of_list():
@@ -132,6 +134,7 @@ def test_NarouURLBuilder_only_of_list():
     assert "out=" not in url  # 出力形式が含まれない
     assert "ncode=" not in url  # ncodeが含まれない
     assert "order=" not in url  # orderが含まれない
+    assert "lim=" not in url  # limitが含まれない
 
 
 def test_NarouURLBuilder_only_order():
@@ -141,6 +144,7 @@ def test_NarouURLBuilder_only_order():
     assert "out=" not in url  # 出力形式が含まれない
     assert "ncode=" not in url  # ncodeが含まれない
     assert "of=" not in url  # ofが含まれない
+    assert "lim=" not in url  # limitが含まれない
 
 
 def test_NarouURLBuilder_combined_params():
@@ -151,12 +155,38 @@ def test_NarouURLBuilder_combined_params():
         .set_ncode("N1234")
         .set_of_list([NarouOfType.TITLE, NarouOfType.WRITER])
         .set_order(NarouOrderType.NEW)
+        .set_limit(500)
         .build()
     )
     assert "out=json" in url  # 出力形式が含まれる
     assert "ncode=N1234" in url  # ncodeが含まれる
     assert "of=t-w" in url  # 項目リストが含まれる
     assert "order=new" in url  # 出力順序が含まれる
+    assert "lim=500" in url  # 出力数が含まれる
+
+
+def test_test_NarouURLBuilder__0():
+    """limitが0の場合のテスト."""
+    url = NarouURLBuilder().set_limit(0).build()
+    assert "lim=1" in url
+
+
+def test_test_NarouURLBuilder_less_than_0():
+    """limitが0未満の場合のテスト."""
+    url = NarouURLBuilder().set_limit(-1).build()
+    assert "lim=1" in url
+
+
+def test_test_NarouURLBuilder_500():
+    """limitが500の場合のテスト."""
+    url = NarouURLBuilder().set_limit(500).build()
+    assert "lim=500" in url
+
+
+def test_test_NarouURLBuilder_greater_than_500():
+    """limitが500より大きい場合のテスト."""
+    url = NarouURLBuilder().set_limit(501).build()
+    assert "lim=500" in url
 
 
 def test_NarouURLBuilder_no_params():


### PR DESCRIPTION
- [小説家になろうAPI](https://dev.syosetu.com/man/api/#get-parameter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- APIリクエストの出力制限を指定するための新しいパラメータ「limit」を追加
	- 結果の数を1〜500の範囲で制御可能

- **テスト**
	- リミットパラメータの検証に関する新しいテストケースを追加
	- 異なる入力値に対するリミット設定の動作を確認

<!-- end of auto-generated comment: release notes by coderabbit.ai -->