### PR TITLE
Version3 flow

### DIFF
--- a/application/apis/narou/type.py
+++ b/application/apis/narou/type.py
@@ -139,3 +139,10 @@ class NarouOfType(Enum):
     KAIWARITU = "ka"
     NOVELUPDATED_AT = "nu"
     UPDATED_AT = "ua"
+
+
+class NarouLimitType(Enum):
+    """なろうAPIで指定する出力数の定数."""
+
+    MIN_FETCH_LIMIT = 1
+    MAX_FETCH_LIMIT = 500

--- a/application/apis/narou/urls.py
+++ b/application/apis/narou/urls.py
@@ -2,7 +2,13 @@
 
 from enum import Enum
 
-from apis.narou.type import NarouOfType, NarouOrderType, OutType, RankType
+from apis.narou.type import (
+    NarouLimitType,
+    NarouOfType,
+    NarouOrderType,
+    OutType,
+    RankType,
+)
 
 # なろうAPI関連
 
@@ -53,11 +59,11 @@ class NarouURLBuilder:
         return self
 
     def set_limit(self, limit: int):
-        """出力数を指定(1 ~ 500)."""
-        if limit <= 0:
-            limit = 1
-        elif limit > 500:
-            limit = 500
+        """出力数を指定."""
+        if limit < NarouLimitType.MIN_FETCH_LIMIT.value:
+            limit = NarouLimitType.MIN_FETCH_LIMIT.value
+        elif limit > NarouLimitType.MAX_FETCH_LIMIT.value:
+            limit = NarouLimitType.MAX_FETCH_LIMIT.value
         self._params[NarouParamsKey.LIMIT.value] = limit
         return self
 

--- a/application/batch/get_novel_data.py
+++ b/application/batch/get_novel_data.py
@@ -200,7 +200,9 @@ def get_novel_data():
     # 取得最大値ずつ区切って並列実行
     # (APIの最大取得件数を考慮するため)
     console_logger.info("flow-1-2 fetch_novel_infoを実行")
-    chunk_data_list = get_chunk_list(data_list, 500)
+    chunk_data_list = get_chunk_list(
+        data_list, NarouLimitType.MAX_FETCH_LIMIT.value
+    )
     fetch_data_list = fetch_novel_info.map(chunk_data_list).result()
 
     # 1-3 insert_novel_into_dbを実行

--- a/application/batch/get_novel_data.py
+++ b/application/batch/get_novel_data.py
@@ -200,8 +200,8 @@ def get_novel_data():
     # 500件ずつ区切って並列実行
     # (APIの最大取得件数が500件なため)
     console_logger.info("flow-1-2 fetch_novel_infoを実行")
-    chunke_data_list = get_chunk_list(data_list, 500)
-    fetch_data_list = fetch_novel_info.map(chunke_data_list).result()
+    chunk_data_list = get_chunk_list(data_list, 500)
+    fetch_data_list = fetch_novel_info.map(chunk_data_list).result()
 
     # 1-3 insert_novel_into_dbを実行
     # データをまとめて1回だけ実行

--- a/application/batch/get_novel_data.py
+++ b/application/batch/get_novel_data.py
@@ -2,13 +2,14 @@
 
 import itertools
 
-from prefect import task
+from prefect import flow, task
 
 from apis.narou.narou_data import NarouData, NarouDataMapper
 from apis.narou.type import NarouOfType, NarouOrderType, OutType
 from apis.narou.urls import NarouURLBuilder
 from apis.request import request_get
 from batch.data import NcodeMappingData
+from common.datetime_util import jst_now
 from config.db import get_session
 from config.log import console_logger
 from models.author import get_author_id
@@ -27,13 +28,15 @@ def get_target_from_db() -> list[NcodeMappingData]:
     """取得対象をDBから取得."""
     console_logger.info("取得対象をDBから取得")
     # 1-1 ncode_mappingとnovelテーブルから取得対象を取得
-    console_logger.info("1-1 ncode_mappingとnovelテーブルから取得対象を取得")
+    console_logger.info(
+        "task-1-1 ncode_mappingとnovelテーブルから取得対象を取得"
+    )
     with get_session() as session:
         data_list = get_target_novel_data(session)
 
     # 1-2 取得したい小説のリストを作成
     # 1-3 return data_list
-    console_logger.info("1-2 取得したい小説のリストを作成")
+    console_logger.info("task-1-2 取得したい小説のリストを作成")
     return list(map(lambda x: NcodeMappingData(**x), data_list))
 
 
@@ -42,7 +45,7 @@ def fetch_novel_info(data_list: list[NcodeMappingData]):
     """小説情報を取得."""
     console_logger.info("小説情報を取得")
     # 2-1 data_listを整形
-    console_logger.info("2-1 data_listを整形")
+    console_logger.info("task-2-1 data_listを整形")
 
     ## data_listが空リストの場合はそのまま返却
     if not data_list:
@@ -53,7 +56,7 @@ def fetch_novel_info(data_list: list[NcodeMappingData]):
 
     # 2-2 なろうAPIから小説情報を取得
     ## t-u-n-w-bg-g-k-nt-ir-ibl-igl-izk-its-iti
-    console_logger.info("2-2 なろうAPIから小説情報を取得")
+    console_logger.info("task-2-2 なろうAPIから小説情報を取得")
     of_list = [
         NarouOfType.TITLE,
         NarouOfType.USERID,
@@ -76,9 +79,10 @@ def fetch_novel_info(data_list: list[NcodeMappingData]):
         .set_order(NarouOrderType.NCODE_DESC)
         .set_output_format(OutType.JSON)
         .set_of_list(of_list)
+        .set_limit(len(ncode_list))
         .build()
     )
-    console_logger.info(f"生成したURL: {url}")
+    console_logger.debug(f"生成したURL: {url}")
     response = request_get(url)
     if response is None:
         console_logger.error("レスポンスが200以外のため終了")
@@ -92,18 +96,21 @@ def fetch_novel_info(data_list: list[NcodeMappingData]):
 def insert_novel_into_db(insert_data_list: list[NarouData]):
     """小説情報をDBへ登録."""
     # 3.1 insert_data_listをDB登録用に整形
-    console_logger.info("3.1 insert_data_listをDB登録用に整形")
+    console_logger.info("task-3.1 insert_data_listをDB登録用に整形")
     insert_keyword_list = get_insert_keyword_list(insert_data_list)
     insert_author_novel_list = get_insert_author_novel_list(insert_data_list)
     insert_novel_keyword_list = get_insert_novel_keyword_list(insert_data_list)
 
     # 3.2 各テーブルにデータを登録
-    console_logger.info("3.2 各テーブルにデータを登録")
+    console_logger.info("task-3.2 各テーブルにデータを登録")
     with get_session() as session:
         insert_keyword(session, insert_keyword_list)
         insert_author(session, insert_author_novel_list)
         insert_novel(session, insert_author_novel_list)
         insert_novel_keywords(session, insert_novel_keyword_list)
+
+        # 全て登録された場合のみ適用
+        session.commit()
 
 
 def get_insert_keyword_list(insert_data_list: list[NarouData]):
@@ -153,3 +160,51 @@ def get_insert_novel_keyword_list(insert_data_list: list[NarouData]):
             novel_keyword_data["keyword"] = keyword
             insert_novel_keyword_list.append(novel_keyword_data)
     return insert_novel_keyword_list
+
+
+def generate_flow_run_name():
+    """実行時の名前を生成."""
+    date = jst_now().strftime("%Y%m%d")
+    return f"get_novel_data_{date}"
+
+
+def get_chunk_list(input_list: list, chunk_size: int):
+    """指定されたサイズでリストを分割する関数.
+
+    Parameters:
+        input_list (list): 分割するリスト.
+        chunk_size (int): 各チャンクのサイズ .
+
+    Returns:
+        list: 分割されたリストのリスト。
+    """
+    return [
+        input_list[i : i + chunk_size]
+        for i in range(0, len(input_list), chunk_size)
+    ]
+
+
+@flow(flow_run_name=generate_flow_run_name)
+def get_novel_data():
+    """小説情報取得バッチ."""
+    # 1-1 get_target_from_dbを実行
+    # 1回だけ実行
+    # data_listが空の場合は終了
+    console_logger.info("flow-1-1 get_target_from_dbを実行")
+    data_list = get_target_from_db()
+    if not data_list:
+        console_logger.info("対象のデータが存在しないため、処理を終了")
+        return
+
+    # 1-2 fetch_novel_infoを実行
+    # 500件ずつ区切って並列実行
+    # (APIの最大取得件数が500件なため)
+    console_logger.info("flow-1-2 fetch_novel_infoを実行")
+    chunke_data_list = get_chunk_list(data_list, 500)
+    fetch_data_list = fetch_novel_info.map(chunke_data_list).result()
+
+    # 1-3 insert_novel_into_dbを実行
+    # データをまとめて1回だけ実行
+    console_logger.info("flow-1-3 insert_novel_into_dbを実行")
+    insert_data_list = list(itertools.chain.from_iterable(fetch_data_list))
+    insert_novel_into_db(insert_data_list)

--- a/application/batch/get_novel_data.py
+++ b/application/batch/get_novel_data.py
@@ -5,7 +5,7 @@ import itertools
 from prefect import flow, task
 
 from apis.narou.narou_data import NarouData, NarouDataMapper
-from apis.narou.type import NarouOfType, NarouOrderType, OutType
+from apis.narou.type import NarouLimitType, NarouOfType, NarouOrderType, OutType
 from apis.narou.urls import NarouURLBuilder
 from apis.request import request_get
 from batch.data import NcodeMappingData
@@ -197,8 +197,8 @@ def get_novel_data():
         return
 
     # 1-2 fetch_novel_infoを実行
-    # 500件ずつ区切って並列実行
-    # (APIの最大取得件数が500件なため)
+    # 取得最大値ずつ区切って並列実行
+    # (APIの最大取得件数を考慮するため)
     console_logger.info("flow-1-2 fetch_novel_infoを実行")
     chunk_data_list = get_chunk_list(data_list, 500)
     fetch_data_list = fetch_novel_info.map(chunk_data_list).result()

--- a/application/main.py
+++ b/application/main.py
@@ -2,9 +2,11 @@
 
 from prefect import serve
 
+from batch.get_novel_data import get_novel_data
 from batch.get_ranking import get_ranking
 
 if __name__ == "__main__":
+    # get_rankingの設定
     daily_get_ranking = get_ranking.to_deployment(
         name="daily_get_ranking",
         cron="0 14 * * *",
@@ -25,9 +27,18 @@ if __name__ == "__main__":
         cron="0 14 1 1,4,7,10 *",
         parameters={"rank_type": "q"},
     )
+
+    # get_novel_dataの設定
+    daily_get_novel_data = get_novel_data.to_deployment(
+        name="daily_get_novel_data",
+        cron="30 14 * * *",
+    )
+
+    # 起動
     serve(
         daily_get_ranking,
         weekly_get_ranking,
         monthly_get_ranking,
         quarterly_get_ranking,
+        daily_get_novel_data,
     )

--- a/application/main.py
+++ b/application/main.py
@@ -6,22 +6,31 @@ from batch.get_novel_data import get_novel_data
 from batch.get_ranking import get_ranking
 
 if __name__ == "__main__":
+    # cronはUTC前提で記述
+
     # get_rankingの設定
+    # 毎日、日本時間の23:00に実行予定
     daily_get_ranking = get_ranking.to_deployment(
         name="daily_get_ranking",
         cron="0 14 * * *",
         parameters={"rank_type": "d"},
     )
+
+    # 火曜日、日本時間の23:00に実行予定
     weekly_get_ranking = get_ranking.to_deployment(
         name="weekly_get_ranking",
         cron="0 14 * * 2",
         parameters={"rank_type": "w"},
     )
+
+    # 1日、日本時間の23:00に実行予定
     monthly_get_ranking = get_ranking.to_deployment(
         name="monthly_get_ranking",
         cron="0 14 1 * *",
         parameters={"rank_type": "m"},
     )
+
+    # 1,4,7,10月の1日、日本時間の23:00に実行予定
     quarterly_get_ranking = get_ranking.to_deployment(
         name="quarterly_get_ranking",
         cron="0 14 1 1,4,7,10 *",
@@ -29,6 +38,7 @@ if __name__ == "__main__":
     )
 
     # get_novel_dataの設定
+    # 毎日、日本時間の23:30に実行予定
     daily_get_novel_data = get_novel_data.to_deployment(
         name="daily_get_novel_data",
         cron="30 14 * * *",

--- a/application/tests/apis/narou/test_urls.py
+++ b/application/tests/apis/narou/test_urls.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from apis.narou.type import NarouOfType, NarouOrderType, OutType, RankType
+from apis.narou.type import (
+    NarouLimitType,
+    NarouOfType,
+    NarouOrderType,
+    OutType,
+    RankType,
+)
 from apis.narou.urls import NarouRankURLBuilder, NarouURLBuilder
 
 
@@ -155,38 +161,56 @@ def test_NarouURLBuilder_combined_params():
         .set_ncode("N1234")
         .set_of_list([NarouOfType.TITLE, NarouOfType.WRITER])
         .set_order(NarouOrderType.NEW)
-        .set_limit(500)
+        .set_limit(NarouLimitType.MAX_FETCH_LIMIT.value)
         .build()
     )
     assert "out=json" in url  # 出力形式が含まれる
     assert "ncode=N1234" in url  # ncodeが含まれる
     assert "of=t-w" in url  # 項目リストが含まれる
     assert "order=new" in url  # 出力順序が含まれる
-    assert "lim=500" in url  # 出力数が含まれる
+    assert (
+        f"lim={NarouLimitType.MAX_FETCH_LIMIT.value}" in url
+    )  # 出力数が含まれる
 
 
-def test_test_NarouURLBuilder__0():
-    """limitが0の場合のテスト."""
-    url = NarouURLBuilder().set_limit(0).build()
-    assert "lim=1" in url
+def test_test_NarouURLBuilder_min_value():
+    """limitが最小値の場合のテスト."""
+    url = (
+        NarouURLBuilder()
+        .set_limit(NarouLimitType.MIN_FETCH_LIMIT.value)
+        .build()
+    )
+    assert f"lim={NarouLimitType.MIN_FETCH_LIMIT.value}" in url
 
 
-def test_test_NarouURLBuilder_less_than_0():
-    """limitが0未満の場合のテスト."""
-    url = NarouURLBuilder().set_limit(-1).build()
-    assert "lim=1" in url
+def test_test_NarouURLBuilder_less_than_min():
+    """limitが最小値未満の場合のテスト."""
+    url = (
+        NarouURLBuilder()
+        .set_limit(NarouLimitType.MIN_FETCH_LIMIT.value - 1)
+        .build()
+    )
+    assert f"lim={NarouLimitType.MIN_FETCH_LIMIT.value}" in url
 
 
-def test_test_NarouURLBuilder_500():
-    """limitが500の場合のテスト."""
-    url = NarouURLBuilder().set_limit(500).build()
-    assert "lim=500" in url
+def test_test_NarouURLBuilder_max():
+    """limitが最大値の場合のテスト."""
+    url = (
+        NarouURLBuilder()
+        .set_limit(NarouLimitType.MAX_FETCH_LIMIT.value)
+        .build()
+    )
+    assert f"lim={NarouLimitType.MAX_FETCH_LIMIT.value}" in url
 
 
 def test_test_NarouURLBuilder_greater_than_500():
-    """limitが500より大きい場合のテスト."""
-    url = NarouURLBuilder().set_limit(501).build()
-    assert "lim=500" in url
+    """limitが最大値より大きい場合のテスト."""
+    url = (
+        NarouURLBuilder()
+        .set_limit(NarouLimitType.MAX_FETCH_LIMIT.value + 1)
+        .build()
+    )
+    assert f"lim={NarouLimitType.MAX_FETCH_LIMIT.value}" in url
 
 
 def test_NarouURLBuilder_no_params():

--- a/application/tests/apis/narou/test_urls.py
+++ b/application/tests/apis/narou/test_urls.py
@@ -203,7 +203,7 @@ def test_test_NarouURLBuilder_max():
     assert f"lim={NarouLimitType.MAX_FETCH_LIMIT.value}" in url
 
 
-def test_test_NarouURLBuilder_greater_than_500():
+def test_test_NarouURLBuilder_greater_than_max():
     """limitが最大値より大きい場合のテスト."""
     url = (
         NarouURLBuilder()

--- a/application/tests/batch/test_get_novel_data.py
+++ b/application/tests/batch/test_get_novel_data.py
@@ -8,6 +8,7 @@ from apis.narou.narou_data import NarouData
 from batch.data import NcodeMappingData
 from batch.get_novel_data import (
     fetch_novel_info,
+    get_chunk_list,
     get_insert_author_novel_list,
     get_insert_keyword_list,
     get_insert_novel_keyword_list,
@@ -235,3 +236,31 @@ def test_get_insert_novel_keyword_list(insert_data_list):
     assert results[4].get("keyword") == "A4"
     assert results[5].get("id") == insert_data_list[1].id
     assert results[5].get("keyword") == "A5"
+
+
+# get_chunk_list関連
+
+
+def test_get_chunk_list():
+    """正常系のテスト."""
+    # 1から1999までのリスト
+    large_list = list(range(1, 2000))
+
+    chunk_data_list = get_chunk_list(large_list, 500)
+
+    assert len(chunk_data_list) == 4
+    assert len(chunk_data_list[0]) == 500
+    assert len(chunk_data_list[1]) == 500
+    assert len(chunk_data_list[2]) == 500
+    assert len(chunk_data_list[3]) == 499
+
+
+def test_below_500_get_chunk_list():
+    """500未満の場合のテスト."""
+    # 1から499までのリスト
+    large_list = list(range(1, 500))
+
+    chunk_data_list = get_chunk_list(large_list, 500)
+
+    assert len(chunk_data_list) == 1
+    assert len(chunk_data_list[0]) == 499


### PR DESCRIPTION
https://github.com/takuron1996/narou_novel_batch/pull/17 の修正が反映されると正常に動作。
（現状は20件ずつしか登録できない。）

上記マージ後にマージのほどお願いいたします。

- [小説情報取得バッチ](https://knowledge-sharing.esa.io/posts/1058)
一部仕様書が古いため、マージ後にメンテナンス予定です。 
（flow-1-2のfetch_novel_infoを実行にて並列実行していることなどが未記述）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 小説データの取得と挿入のための新しいバッチ処理フローを追加
	- 日次で小説データを自動取得するデイリースケジュールを導入
	- データ取得の最小・最大制限を管理する新しい列挙型を追加

- **テスト**
	- 新しいデータチャンク分割機能のテストケースを追加
	- リストの分割と処理に関する検証を実施
	- URLビルダーの制限値に関するテストを強化

- **改善**
	- データ取得プロセスのログ記録と構造を最適化
	- データベース挿入の信頼性を向上
	- URLビルダーの制限設定ロジックを柔軟に変更

<!-- end of auto-generated comment: release notes by coderabbit.ai -->